### PR TITLE
Feature/batched prompt generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ datadreamer --save_dir <directory> --class_names <objects> --prompts_number <num
 - `--use_image_tester`: Use image tester for image generation. Default is False.
 - `--image_tester_patience`: Patience level for image tester. Default is 1.
 - `--lm_quantization`: Quantization to use for Mistral language model. Choose between `none` and `4bit`. Default is `none`.
+- `--batch_size_prompt`: Batch size for prompt generation. Default is 1.
 - `--device`: Choose between `cuda` and `cpu`. Default is cuda.
 - `--seed`: Set a random seed for image and prompt generation. Default is 42.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ datadreamer --save_dir <directory> --class_names <objects> --prompts_number <num
 - `--use_image_tester`: Use image tester for image generation. Default is False.
 - `--image_tester_patience`: Patience level for image tester. Default is 1.
 - `--lm_quantization`: Quantization to use for Mistral language model. Choose between `none` and `4bit`. Default is `none`.
-- `--batch_size_prompt`: Batch size for prompt generation. Default is 1.
+- `--batch_size_prompt`: Batch size for prompt generation. Default is 64.
 - `--device`: Choose between `cuda` and `cpu`. Default is cuda.
 - `--seed`: Set a random seed for image and prompt generation. Default is 42.
 

--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -139,6 +139,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--batch_size_prompt",
+        type=int,
+        default=1,
+        help="Batch size for prompt generation",
+    )
+
+    parser.add_argument(
         "--device",
         type=str,
         default="cuda",
@@ -210,6 +217,10 @@ def check_args(args):
             "LM Quantization is only available for CUDA devices and Mistral LM"
         )
 
+    # Check batch_size_prompt
+    if args.batch_size_prompt < 1:
+        raise ValueError("--batch_size_prompt must be a positive integer")
+
     # Check seed
     if args.seed < 0:
         raise ValueError("--seed must be a non-negative integer")
@@ -279,6 +290,7 @@ def main():
         seed=args.seed,
         device=args.device,
         quantization=args.lm_quantization,
+        batch_size=args.batch_size_prompt,
     )
     generated_prompts = prompt_generator.generate_prompts()
     prompt_generator.save_prompts(

--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -141,7 +141,7 @@ def parse_args():
     parser.add_argument(
         "--batch_size_prompt",
         type=int,
-        default=1,
+        default=64,
         help="Batch size for prompt generation",
     )
 

--- a/datadreamer/prompt_generation/lm_prompt_generator.py
+++ b/datadreamer/prompt_generation/lm_prompt_generator.py
@@ -227,7 +227,6 @@ class LMPromptGenerator(PromptGenerator):
                 selected_objects_batch
             )
             generated_prompts_batch = self.generate_prompts_batch(prompt_texts_batch)
-            print(f"Generated {len(generated_prompts_batch)} prompts.")
             for generated_prompt, selected_objects in zip(
                 generated_prompts_batch, selected_objects_batch
             ):

--- a/datadreamer/prompt_generation/lm_prompt_generator.py
+++ b/datadreamer/prompt_generation/lm_prompt_generator.py
@@ -156,7 +156,7 @@ class LMPromptGenerator(PromptGenerator):
             for selected_objects in selected_objects_batch
         ]
 
-    def _posprocess_prompt(self, prompt: str) -> str:
+    def _postprocess_prompt(self, prompt: str) -> str:
         """Post-processes the generated prompt.
 
         Args:
@@ -203,7 +203,7 @@ class LMPromptGenerator(PromptGenerator):
             pad_token_id=self.tokenizer.eos_token_id,
         )
         decoded_prompts = [
-            self._posprocess_prompt(sequence[0]["generated_text"])
+            self._postprocess_prompt(sequence[0]["generated_text"])
             for sequence in sequences
         ]
         return decoded_prompts

--- a/datadreamer/prompt_generation/lm_prompt_generator.py
+++ b/datadreamer/prompt_generation/lm_prompt_generator.py
@@ -40,6 +40,7 @@ class LMPromptGenerator(PromptGenerator):
         class_names: List[str],
         prompts_number: int = 10,
         num_objects_range: Optional[List[int]] = None,
+        batch_size: int = 1,
         seed: Optional[float] = 42,
         device: str = "cuda",
         quantization: Optional[Literal["none", "4bit"]] = "none",
@@ -47,7 +48,13 @@ class LMPromptGenerator(PromptGenerator):
         """Initializes the LMPromptGenerator with class names and other settings."""
         num_objects_range = num_objects_range or [1, 3]
         super().__init__(
-            class_names, prompts_number, num_objects_range, seed, device, quantization
+            class_names,
+            prompts_number,
+            num_objects_range,
+            batch_size,
+            seed,
+            device,
+            quantization,
         )
         self.model, self.tokenizer, self.pipeline = self._init_lang_model()
 
@@ -96,12 +103,14 @@ class LMPromptGenerator(PromptGenerator):
                 )
 
         tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+        tokenizer.pad_token = tokenizer.eos_token
         pipe = pipeline(
             "text-generation",
             model=model,
             tokenizer=tokenizer,
             torch_dtype=selected_dtype,
             device_map=self.device,
+            batch_size=self.batch_size,
         )
         print("Done!")
         return model, tokenizer, pipe
@@ -131,6 +140,39 @@ class LMPromptGenerator(PromptGenerator):
         """
         return f"[INST] Generate a short and concise caption for an image. Follow this template: 'A photo of {', '.join(selected_objects)}', where the objects interact in a meaningful way within a scene, complete with a short scene description. [/INST]"
 
+    def _create_lm_prompt_texts_batch(
+        self, selected_objects_batch: List[List[str]]
+    ) -> List[str]:
+        """Creates a list of language model text prompts based on selected objects.
+
+        Args:
+            selected_objects_batch (List[List[str]]): List of objects to include in the prompts.
+
+        Returns:
+            List[str]: List of text prompts for the language model.
+        """
+        return [
+            self._create_lm_prompt_text(selected_objects)
+            for selected_objects in selected_objects_batch
+        ]
+
+    def _posprocess_prompt(self, prompt: str) -> str:
+        """Post-processes the generated prompt.
+
+        Args:
+            prompt (str): The generated prompt.
+
+        Returns:
+            str: The post-processed prompt.
+        """
+        instructional_pattern = r"\[INST].*?\[/INST\]\s*"
+        # Remove the instructional text to isolate the caption
+        prompt = (
+            re.sub(instructional_pattern, "", prompt).replace('"', "").replace("'", "")
+        )
+        prompt = self._remove_incomplete_sentence(prompt)
+        return prompt
+
     def _test_prompt(self, prompt: str, selected_objects: List[str]) -> bool:
         """Tests if the generated prompt is valid based on selected objects.
 
@@ -145,31 +187,26 @@ class LMPromptGenerator(PromptGenerator):
             "a photo of"
         )  # and all(obj.lower() in prompt.lower() for obj in selected_objects)
 
-    def generate_prompt(self, prompt_text: str) -> str:
-        """Generates a single prompt using the language model.
+    def generate_prompts_batch(self, prompt_texts_batch: List[str]) -> List[str]:
+        """Generates a list of prompts using the language model.
 
         Args:
-            prompt_text (str): The text prompt for the language model.
+            prompt_texts_batch (List[str]): List of text prompts for the language model.
 
         Returns:
-            str: The generated prompt.
+            List[str]: List of generated prompts.
         """
         sequences = self.pipeline(
-            prompt_text,
+            prompt_texts_batch,
             max_new_tokens=70,
             do_sample=True,
             pad_token_id=self.tokenizer.eos_token_id,
         )
-        decoded_prompt = sequences[0]["generated_text"]
-        instructional_pattern = r"\[INST].*?\[/INST\]\s*"
-        # Remove the instructional text to isolate the caption
-        decoded_prompt = (
-            re.sub(instructional_pattern, "", decoded_prompt)
-            .replace('"', "")
-            .replace("'", "")
-        )
-
-        return self._remove_incomplete_sentence(decoded_prompt)
+        decoded_prompts = [
+            self._posprocess_prompt(sequence[0]["generated_text"])
+            for sequence in sequences
+        ]
+        return decoded_prompts
 
     def generate_prompts(self) -> List[str]:
         """Generates a list of text prompts based on the class names.
@@ -178,17 +215,29 @@ class LMPromptGenerator(PromptGenerator):
             List[str]: A list of generated prompts.
         """
         prompts = []
-        for _ in tqdm(range(self.prompts_number), desc="Generating prompts"):
-            selected_objects = random.sample(
-                self.class_names, random.randint(*self.num_objects_range)
+        progress_bar = tqdm(
+            desc="Generating prompts...", position=0, total=self.prompts_number
+        )
+        while len(prompts) < self.prompts_number:
+            selected_objects_batch = [
+                random.sample(self.class_names, random.randint(*self.num_objects_range))
+                for _ in range(self.batch_size)
+            ]
+            prompt_texts_batch = self._create_lm_prompt_texts_batch(
+                selected_objects_batch
             )
-            prompt_text = self._create_lm_prompt_text(selected_objects)
-            correct_prompt_generated = False
-            while not correct_prompt_generated:
-                generated_prompt = self.generate_prompt(prompt_text)
+            generated_prompts_batch = self.generate_prompts_batch(prompt_texts_batch)
+            print(f"Generated {len(generated_prompts_batch)} prompts.")
+            for generated_prompt, selected_objects in zip(
+                generated_prompts_batch, selected_objects_batch
+            ):
                 if self._test_prompt(generated_prompt, selected_objects):
                     prompts.append((selected_objects, generated_prompt))
-                    correct_prompt_generated = True
+                    progress_bar.update()
+                if len(prompts) == self.prompts_number:
+                    break
+
+        progress_bar.close()
         return prompts
 
     def release(self, empty_cuda_cache=False) -> None:

--- a/datadreamer/prompt_generation/prompt_generator.py
+++ b/datadreamer/prompt_generation/prompt_generator.py
@@ -30,6 +30,7 @@ class PromptGenerator(ABC):
         class_names: List[str],
         prompts_number: int = 10,
         num_objects_range: Optional[List[int]] = None,
+        batch_size: int = 1,
         seed: Optional[float] = None,
         device: str = "cuda",
         quantization: Optional[Literal["none", "4bit"]] = "none",
@@ -38,6 +39,7 @@ class PromptGenerator(ABC):
         self.class_names = class_names
         self.prompts_number = prompts_number
         self.num_objects_range = num_objects_range or [1, 3]
+        self.batch_size = batch_size
         self.seed = seed
         if seed is not None:
             self.set_seed(seed)

--- a/datadreamer/prompt_generation/tinyllama_lm_prompt_generator.py
+++ b/datadreamer/prompt_generation/tinyllama_lm_prompt_generator.py
@@ -112,7 +112,7 @@ class TinyLlamaLMPromptGenerator(LMPromptGenerator):
         """
         return f"<|system|>\nYou are a chatbot who describes content of images!</s>\n<|user|>\nGenerate a short and concise caption for an image. Follow this template: 'A photo of {', '.join(selected_objects)}', where the objects interact in a meaningful way within a scene, complete with a short scene description. The caption must be short in length and start with the words: 'A photo of '! Do not use the phrase 'Caption reads'.</s>\n<|assistant|>\n"
 
-    def _posprocess_prompt(self, prompt: str) -> str:
+    def _postprocess_prompt(self, prompt: str) -> str:
         """Post-processes the generated prompt.
 
         Args:
@@ -151,7 +151,7 @@ class TinyLlamaLMPromptGenerator(LMPromptGenerator):
             pad_token_id=self.tokenizer.eos_token_id,
         )
         decoded_prompts = [
-            self._posprocess_prompt(sequence[0]["generated_text"])
+            self._postprocess_prompt(sequence[0]["generated_text"])
             for sequence in sequences
         ]
 

--- a/examples/measure_batched_prompt_gen_speed.py
+++ b/examples/measure_batched_prompt_gen_speed.py
@@ -1,0 +1,63 @@
+from datadreamer.prompt_generation import LMPromptGenerator, TinyLlamaLMPromptGenerator
+from tqdm import tqdm
+import time
+
+
+if __name__ == "__main__":
+
+    time_per_prompt_dict = {
+        "tinyllama": {},
+        "mistral_int4": {},
+        "mistral_fp16": {}
+    }
+    for prompt_generator_class, batch_sizes, generator_name in zip(
+        [   
+            TinyLlamaLMPromptGenerator,
+            lambda *args, **kwargs: LMPromptGenerator(*args, **kwargs, quantization="4bit"),
+            lambda *args, **kwargs: LMPromptGenerator(*args, **kwargs, quantization="none"),
+        ],
+        [
+            [2**i for i in range(0, 10)], # tinyllama
+            [2**i for i in range(0, 9)], # mistral_int4
+            [2**i for i in range(0, 8)], # mistral_fp16
+        ],
+        time_per_prompt_dict.keys(),
+    ):
+        for batch_size in batch_sizes:
+            prompt_generator = prompt_generator_class(
+                class_names=["aeroplane", "bicycle", "bird"],
+                prompts_number=1,
+                batch_size=batch_size,
+                device="cuda",
+            )
+            time_start = time.time()
+            generated_prompts = prompt_generator.generate_prompts()
+            print(f"Generator name: {generator_name}")
+            print(f"Batch size: {batch_size}")
+            print(f"Time taken: {time.time() - time_start:.3f} seconds")
+            time_per_prompt = (time.time() - time_start) / batch_size
+            print(f"Time per prompt: {time_per_prompt:.3f} seconds")
+            time_per_prompt_dict[generator_name][batch_size] = round(time_per_prompt, 3)
+            prompt_generator.release(empty_cuda_cache=True)
+
+    max_columns = max(len(batch_sizes) for batch_sizes in time_per_prompt_dict.values())
+
+    # Find the maximum length of model name for formatting
+    max_model_length = max(len(model) for model in time_per_prompt_dict.keys())
+
+    # Print the headers
+    print(f'{"Model":<{max_model_length}}\t', end='')
+    for i in range(0, max_columns):
+        print(f'{2**i}\t\t', end='')
+    print()
+
+    # Print each row of the table
+    for model, batch_size_times in time_per_prompt_dict.items():
+        print(f'{model:<{max_model_length}}\t', end='')
+        for _, time in batch_size_times.items():
+            print(f'{time}\t\t', end='')
+        print()
+
+    
+
+

--- a/examples/measure_batched_prompt_gen_speed.py
+++ b/examples/measure_batched_prompt_gen_speed.py
@@ -1,25 +1,23 @@
-from datadreamer.prompt_generation import LMPromptGenerator, TinyLlamaLMPromptGenerator
-from tqdm import tqdm
 import time
 
+from datadreamer.prompt_generation import LMPromptGenerator, TinyLlamaLMPromptGenerator
 
 if __name__ == "__main__":
-
-    time_per_prompt_dict = {
-        "tinyllama": {},
-        "mistral_int4": {},
-        "mistral_fp16": {}
-    }
+    time_per_prompt_dict = {"tinyllama": {}, "mistral_int4": {}, "mistral_fp16": {}}
     for prompt_generator_class, batch_sizes, generator_name in zip(
-        [   
+        [
             TinyLlamaLMPromptGenerator,
-            lambda *args, **kwargs: LMPromptGenerator(*args, **kwargs, quantization="4bit"),
-            lambda *args, **kwargs: LMPromptGenerator(*args, **kwargs, quantization="none"),
+            lambda *args, **kwargs: LMPromptGenerator(
+                *args, **kwargs, quantization="4bit"
+            ),
+            lambda *args, **kwargs: LMPromptGenerator(
+                *args, **kwargs, quantization="none"
+            ),
         ],
         [
-            [2**i for i in range(0, 10)], # tinyllama
-            [2**i for i in range(0, 9)], # mistral_int4
-            [2**i for i in range(0, 8)], # mistral_fp16
+            [2**i for i in range(0, 10)],  # tinyllama
+            [2**i for i in range(0, 9)],  # mistral_int4
+            [2**i for i in range(0, 8)],  # mistral_fp16
         ],
         time_per_prompt_dict.keys(),
     ):
@@ -46,18 +44,14 @@ if __name__ == "__main__":
     max_model_length = max(len(model) for model in time_per_prompt_dict.keys())
 
     # Print the headers
-    print(f'{"Model":<{max_model_length}}\t', end='')
+    print(f'{"Model":<{max_model_length}}\t', end="")
     for i in range(0, max_columns):
-        print(f'{2**i}\t\t', end='')
+        print(f"{2**i}\t\t", end="")
     print()
 
     # Print each row of the table
     for model, batch_size_times in time_per_prompt_dict.items():
-        print(f'{model:<{max_model_length}}\t', end='')
-        for _, time in batch_size_times.items():
-            print(f'{time}\t\t', end='')
+        print(f"{model:<{max_model_length}}\t", end="")
+        for _, time_per_prompt in batch_size_times.items():
+            print(f"{time_per_prompt}\t\t", end="")
         print()
-
-    
-
-

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -162,6 +162,12 @@ def test_invalid_device_lm_quantization():
     _check_wrong_value(cmd)
 
 
+def test_invalid_batch_size_prompt():
+    # Define the cmd
+    cmd = "datadreamer --batch_size_prompt -1"
+    _check_wrong_value(cmd)
+
+
 def test_invalid_num_objects_range():
     # Define the cmd
     cmd = "datadreamer --num_objects_range 1"


### PR DESCRIPTION
- Add batch prompt generation.
- Default `batch_size_prompt `is set to 64 (TinyLlama and Mistral-4bit should fit into an 8GB GPU).
- Replace the `generate_prompt()` function with `generate_prompts_batch()`.

Output of the script `datadreamer/examples/measure_batched_prompt_gen_speed.py`:
```
Model           1               2               4               8               16              32              64              128             256             512
tinyllama       2.779           1.018           0.507           0.263           0.144           0.071           0.045           0.039           0.036           0.036
mistral_int4    3.096           3.774           1.902           0.963           1.146           0.608           0.341           0.205           0.138
mistral_fp16    1.851           1.172           0.497           0.308           0.309           0.2             0.135           0.1
```
(batch_size x time_per_prompt) - maximal batch size for each model that fits into an NVIDIA L4 24GB GPU.

TinyLlama looks like the best choice. Mistral-Int4 should be used only if GPU memory is less than 16GB.
