### PR TITLE
Fix LLM quantization

### DIFF
--- a/datadreamer/prompt_generation/lm_prompt_generator.py
+++ b/datadreamer/prompt_generation/lm_prompt_generator.py
@@ -97,7 +97,6 @@ class LMPromptGenerator(PromptGenerator):
 
                 model = AutoModelForCausalLM.from_pretrained(
                     "mistralai/Mistral-7B-Instruct-v0.1",
-                    load_in_4bit=True,
                     quantization_config=bnb_config,
                     torch_dtype=selected_dtype,
                     device_map=self.device,


### PR DESCRIPTION
This PR includes a fix for LM 4bit quantization by removing duplicated arg: `load_in_4bit=True`, which causes the following error:
```
ValueError: You can't pass `load_in_4bit`or `load_in_8bit` as a kwarg when passing `quantization_config` argument at the same time.
```