### PR TITLE
Adding WordNet as synonym generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ datadreamer --save_dir <directory> --class_names <objects> --prompts_number <num
 - `--image_annotator`: Specify the image annotator, like `owlv2`. Default is `owlv2`.
 - `--conf_threshold`: Confidence threshold for object detection. Default is 0.15.
 - `--use_tta`: Toggle test time augmentation for object detection. Default is True.
-- `--enhance_class_names`: Enhance class names with synonyms. Default is False.
+- `--synonym_generator`: Enhance class names with synonyms. Default is `none`. Other options are `llm`, `wordnet`.
 - `--use_image_tester`: Use image tester for image generation. Default is False.
 - `--image_tester_patience`: Patience level for image tester. Default is 1.
 - `--lm_quantization`: Quantization to use for Mistral language model. Choose between `none` and `4bit`. Default is `none`.

--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -17,15 +17,21 @@ from datadreamer.image_generation import (
 )
 from datadreamer.prompt_generation import (
     LMPromptGenerator,
+    LMSynonymGenerator,
     SimplePromptGenerator,
-    SynonymGenerator,
     TinyLlamaLMPromptGenerator,
+    WordNetSynonymGenerator,
 )
 
 prompt_generators = {
     "simple": SimplePromptGenerator,
     "lm": LMPromptGenerator,
     "tiny": TinyLlamaLMPromptGenerator,
+}
+
+synonym_generators = {
+    "llm": LMSynonymGenerator,
+    "wordnet": WordNetSynonymGenerator,
 }
 
 image_generators = {
@@ -98,6 +104,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--synonym_generator",
+        type=str,
+        default="none",
+        choices=["none", "llm", "wordnet"],
+        help="Image annotator to use",
+    )
+
+    parser.add_argument(
         "--conf_threshold",
         type=float,
         default=0.15,
@@ -109,13 +123,6 @@ def parse_args():
         default=False,
         action="store_true",
         help="Whether to use test time augmentation for object detection",
-    )
-
-    parser.add_argument(
-        "--enhance_class_names",
-        default=False,
-        action="store_true",
-        help="Whether to enhance class names with synonyms",
     )
 
     parser.add_argument(
@@ -324,8 +331,9 @@ def main():
 
     # Synonym generation
     synonym_dict = None
-    if args.enhance_class_names:
-        synonym_generator = SynonymGenerator(device=args.device)
+    if args.synonym_generator != "none":
+        synonym_generator_class = synonym_generators[args.synonym_generator]
+        synonym_generator = synonym_generator_class(device=args.device)
         synonym_dict = synonym_generator.generate_synonyms_for_list(args.class_names)
         synonym_generator.release(empty_cuda_cache=True)
         synonym_generator.save_synonyms(

--- a/datadreamer/prompt_generation/__init__.py
+++ b/datadreamer/prompt_generation/__init__.py
@@ -1,11 +1,13 @@
 from .lm_prompt_generator import LMPromptGenerator
+from .lm_synonym_generator import LMSynonymGenerator
 from .simple_prompt_generator import SimplePromptGenerator
-from .synonym_generator import SynonymGenerator
 from .tinyllama_lm_prompt_generator import TinyLlamaLMPromptGenerator
+from .wordnet_synonym_generator import WordNetSynonymGenerator
 
 __all__ = [
     "SimplePromptGenerator",
     "LMPromptGenerator",
-    "SynonymGenerator",
+    "LMSynonymGenerator",
     "TinyLlamaLMPromptGenerator",
+    "WordNetSynonymGenerator",
 ]

--- a/datadreamer/prompt_generation/lm_synonym_generator.py
+++ b/datadreamer/prompt_generation/lm_synonym_generator.py
@@ -1,0 +1,166 @@
+import re
+from typing import List, Optional
+
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Pipeline,
+    pipeline,
+)
+
+from .synonym_generator import SynonymGenerator
+
+
+class LMSynonymGenerator(SynonymGenerator):
+    """Synonym generator that generates synonyms for a list of words using a language
+    model.
+
+    Args:
+        synonyms_number (int): Number of synonyms to generate for each word.
+        seed (Optional[float]): Seed for randomization.
+        device (str): Device for model inference (default is "cuda").
+
+    Methods:
+        _init_lang_model(): Initializes the language model and tokenizer.
+        _generate_synonyms(prompt_text): Generates synonyms based on a given prompt text.
+        _extract_synonyms(text): Extracts synonyms from a text containing synonyms.
+        _create_prompt_text(word): Creates a prompt text for generating synonyms for a given word.
+        generate_synonyms(word): Generates synonyms for a single word and returns them in a list.
+        release(empty_cuda_cache): Releases resources (no action is taken in this implementation).
+    """
+
+    def __init__(
+        self,
+        synonyms_number: int = 5,
+        seed: Optional[float] = 42,
+        device: str = "cuda",
+    ) -> None:
+        """Initializes the SynonymGenerator with parameters."""
+        super().__init__(synonyms_number, seed, device)
+        self.model, self.tokenizer, self.pipeline = self._init_lang_model()
+
+    def _init_lang_model(self) -> tuple[AutoModelForCausalLM, AutoTokenizer, Pipeline]:
+        """Initializes the language model, tokenizer and pipeline for prompt generation.
+
+        Returns:
+            tuple: The initialized language model, tokenizer and pipeline.
+        """
+        if self.device == "cpu":
+            print("Loading language model on CPU...")
+            model = AutoModelForCausalLM.from_pretrained(
+                "mistralai/Mistral-7B-Instruct-v0.1",
+                torch_dtype="auto",
+                device_map="cpu",
+                low_cpu_mem_usage=True,
+            )
+        else:
+            print("Loading FP16 language model on GPU...")
+            model = AutoModelForCausalLM.from_pretrained(
+                "mistralai/Mistral-7B-Instruct-v0.1",
+                torch_dtype=torch.float16,
+                trust_remote_code=True,
+                device_map=self.device,
+            )
+
+        tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+        pipe = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+            torch_dtype=torch.float16 if self.device == "cuda" else "auto",
+            device_map=self.device,
+        )
+        print("Done!")
+        return model, tokenizer, pipe
+
+    def _generate_synonyms(self, prompt_text: str) -> List[str]:
+        """Generates synonyms based on a given prompt text.
+
+        Args:
+            prompt_text (str): The prompt text for generating synonyms.
+
+        Returns:
+            List[str]: A list of generated synonyms.
+        """
+        sequences = self.pipeline(
+            prompt_text,
+            max_new_tokens=50,
+            do_sample=True,
+            num_return_sequences=1,
+            pad_token_id=self.tokenizer.eos_token_id,
+        )
+        generated_text = sequences[0]["generated_text"]
+
+        instructional_pattern = r"\[INST].*?\[/INST\]\s*"
+        # Remove the instructional text to isolate the caption
+        generated_text = (
+            re.sub(instructional_pattern, "", generated_text)
+            .replace('"', "")
+            .replace("'", "")
+            .replace(".", "")
+        )
+
+        # Process the generated text to extract synonyms
+        synonyms = self._extract_synonyms(generated_text)
+        return synonyms
+
+    def _extract_synonyms(self, text: str) -> List[str]:
+        """Extracts synonyms from a text containing synonyms.
+
+        Args:
+            text (str): The text containing synonyms.
+
+        Returns:
+            List[str]: A list of extracted synonyms.
+        """
+        synonyms = [
+            word.strip() for word in text.split(",")
+        ]  # Split and strip each synonym
+        return synonyms[: self.synonyms_number]
+
+    def _create_prompt_text(self, word: str) -> str:
+        """Creates a prompt text for generating synonyms for a given word.
+
+        Args:
+            word (str): The word for which synonyms are generated.
+
+        Returns:
+            str: The prompt text for generating synonyms.
+        """
+        return f"[INST] List {self.synonyms_number} most common synonyms for the word '{word}'. Write only synonyms separated by commas. [/INST]"
+
+    def generate_synonyms(self, word: str) -> List[str]:
+        """Generates synonyms for a single word and returns them in a list.
+
+        Args:
+            word (str): The word for which synonyms are generated.
+
+        Returns:
+            List[str]: A list of generated synonyms for the word.
+        """
+        prompt_text = self._create_prompt_text(word)
+        generated_synonyms = self._generate_synonyms(prompt_text)
+        return generated_synonyms
+
+    def release(self, empty_cuda_cache=False) -> None:
+        """Releases resources and optionally empties the CUDA cache.
+
+        Args:
+            empty_cuda_cache (bool): Whether to empty the CUDA cache (default is False).
+        """
+        self.model = self.model.to("cpu")
+        if empty_cuda_cache:
+            with torch.no_grad():
+                torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    # Example usage
+    generator = LMSynonymGenerator(synonyms_number=3, device="cpu")
+    synonyms = generator.generate_synonyms_for_list(
+        ["astronaut", "cat", "dog", "person", "horse"]
+    )
+    print(synonyms)
+    # generator.save_synonyms(synonyms, "synonyms.json")
+    # generator.release()

--- a/datadreamer/prompt_generation/lm_synonym_generator.py
+++ b/datadreamer/prompt_generation/lm_synonym_generator.py
@@ -9,7 +9,7 @@ from transformers import (
     pipeline,
 )
 
-from .synonym_generator import SynonymGenerator
+from datadreamer.prompt_generation.synonym_generator import SynonymGenerator
 
 
 class LMSynonymGenerator(SynonymGenerator):

--- a/datadreamer/prompt_generation/synonym_generator.py
+++ b/datadreamer/prompt_generation/synonym_generator.py
@@ -1,31 +1,20 @@
 import json
-import re
+from abc import ABC, abstractmethod
 from typing import List, Optional
 
-import torch
 from tqdm import tqdm
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    Pipeline,
-    pipeline,
-)
 
 
-class SynonymGenerator:
-    """Synonym generator that generates synonyms for a list of words using a language
-    model.
+# Abstract base class for synonym generation
+class SynonymGenerator(ABC):
+    """Abstract base class for synonym generation.
 
-    Args:
+    Attributes:
         synonyms_number (int): Number of synonyms to generate for each word.
         seed (Optional[float]): Seed for randomization.
-        device (str): Device for model inference (default is "cuda").
+        device (str): Device to run the prompt generator on ('cuda' for GPU, 'cpu' for CPU).
 
     Methods:
-        _init_lang_model(): Initializes the language model and tokenizer.
-        _generate_synonyms(prompt_text): Generates synonyms based on a given prompt text.
-        _extract_synonyms(text): Extracts synonyms from a text containing synonyms.
-        _create_prompt_text(word): Creates a prompt text for generating synonyms for a given word.
         generate_synonyms_for_list(words): Generates synonyms for a list of words and returns them in a dictionary.
         generate_synonyms(word): Generates synonyms for a single word and returns them in a list.
         save_synonyms(synonyms, save_path): Saves the generated synonyms to a JSON file.
@@ -42,97 +31,6 @@ class SynonymGenerator:
         self.synonyms_number = synonyms_number
         self.seed = seed
         self.device = device
-        self.model, self.tokenizer, self.pipeline = self._init_lang_model()
-
-    def _init_lang_model(self) -> tuple[AutoModelForCausalLM, AutoTokenizer, Pipeline]:
-        """Initializes the language model, tokenizer and pipeline for prompt generation.
-
-        Returns:
-            tuple: The initialized language model, tokenizer and pipeline.
-        """
-        if self.device == "cpu":
-            print("Loading language model on CPU...")
-            model = AutoModelForCausalLM.from_pretrained(
-                "mistralai/Mistral-7B-Instruct-v0.1",
-                torch_dtype="auto",
-                device_map="cpu",
-                low_cpu_mem_usage=True,
-            )
-        else:
-            print("Loading FP16 language model on GPU...")
-            model = AutoModelForCausalLM.from_pretrained(
-                "mistralai/Mistral-7B-Instruct-v0.1",
-                torch_dtype=torch.float16,
-                trust_remote_code=True,
-                device_map=self.device,
-            )
-
-        tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
-        pipe = pipeline(
-            "text-generation",
-            model=model,
-            tokenizer=tokenizer,
-            torch_dtype=torch.float16 if self.device == "cuda" else "auto",
-            device_map=self.device,
-        )
-        print("Done!")
-        return model, tokenizer, pipe
-
-    def _generate_synonyms(self, prompt_text: str) -> List[str]:
-        """Generates synonyms based on a given prompt text.
-
-        Args:
-            prompt_text (str): The prompt text for generating synonyms.
-
-        Returns:
-            List[str]: A list of generated synonyms.
-        """
-        sequences = self.pipeline(
-            prompt_text,
-            max_new_tokens=50,
-            do_sample=True,
-            num_return_sequences=1,
-            pad_token_id=self.tokenizer.eos_token_id,
-        )
-        generated_text = sequences[0]["generated_text"]
-
-        instructional_pattern = r"\[INST].*?\[/INST\]\s*"
-        # Remove the instructional text to isolate the caption
-        generated_text = (
-            re.sub(instructional_pattern, "", generated_text)
-            .replace('"', "")
-            .replace("'", "")
-            .replace(".", "")
-        )
-
-        # Process the generated text to extract synonyms
-        synonyms = self._extract_synonyms(generated_text)
-        return synonyms
-
-    def _extract_synonyms(self, text: str) -> List[str]:
-        """Extracts synonyms from a text containing synonyms.
-
-        Args:
-            text (str): The text containing synonyms.
-
-        Returns:
-            List[str]: A list of extracted synonyms.
-        """
-        synonyms = [
-            word.strip() for word in text.split(",")
-        ]  # Split and strip each synonym
-        return synonyms[: self.synonyms_number]
-
-    def _create_prompt_text(self, word: str) -> str:
-        """Creates a prompt text for generating synonyms for a given word.
-
-        Args:
-            word (str): The word for which synonyms are generated.
-
-        Returns:
-            str: The prompt text for generating synonyms.
-        """
-        return f"[INST] List {self.synonyms_number} most common synonyms for the word '{word}'. Write only synonyms separated by commas. [/INST]"
 
     def generate_synonyms_for_list(self, words: List[str]) -> dict:
         """Generates synonyms for a list of words and returns them in a dictionary.
@@ -150,19 +48,6 @@ class SynonymGenerator:
         print("Synonyms generated")
         return synonyms_dict
 
-    def generate_synonyms(self, word: str) -> List[str]:
-        """Generates synonyms for a single word and returns them in a list.
-
-        Args:
-            word (str): The word for which synonyms are generated.
-
-        Returns:
-            List[str]: A list of generated synonyms for the word.
-        """
-        prompt_text = self._create_prompt_text(word)
-        generated_synonyms = self._generate_synonyms(prompt_text)
-        return generated_synonyms
-
     def save_synonyms(self, synonyms, save_path: str) -> None:
         """Saves the generated synonyms to a JSON file.
 
@@ -173,24 +58,18 @@ class SynonymGenerator:
         with open(save_path, "w") as f:
             json.dump(synonyms, f)
 
-    def release(self, empty_cuda_cache=False) -> None:
-        """Releases resources and optionally empties the CUDA cache.
+    @abstractmethod
+    def generate_synonyms(self, word: str) -> List[str]:
+        """Generates synonyms for a single word and returns them in a list.
 
         Args:
-            empty_cuda_cache (bool): Whether to empty the CUDA cache (default is False).
+            word (str): The word for which synonyms are generated.
+
+        Returns:
+            List[str]: A list of generated synonyms for the word.
         """
-        self.model = self.model.to("cpu")
-        if empty_cuda_cache:
-            with torch.no_grad():
-                torch.cuda.empty_cache()
+        pass
 
-
-if __name__ == "__main__":
-    # Example usage
-    generator = SynonymGenerator(synonyms_number=3, device="cpu")
-    synonyms = generator.generate_synonyms_for_list(
-        ["astronaut", "cat", "dog", "person", "horse"]
-    )
-    print(synonyms)
-    # generator.save_synonyms(synonyms, "synonyms.json")
-    # generator.release()
+    def release(self, empty_cuda_cache=False) -> None:
+        """Abstract method to release resources (must be implemented in subclasses)."""
+        pass

--- a/datadreamer/prompt_generation/synonym_generator.py
+++ b/datadreamer/prompt_generation/synonym_generator.py
@@ -70,6 +70,7 @@ class SynonymGenerator(ABC):
         """
         pass
 
+    @abstractmethod
     def release(self, empty_cuda_cache=False) -> None:
         """Abstract method to release resources (must be implemented in subclasses)."""
         pass

--- a/datadreamer/prompt_generation/wordnet_synonym_generator.py
+++ b/datadreamer/prompt_generation/wordnet_synonym_generator.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import nltk
 from nltk.corpus import wordnet
 
-from .synonym_generator import SynonymGenerator
+from datadreamer.prompt_generation.synonym_generator import SynonymGenerator
 
 # Ensure that WordNet data is downloaded
 nltk.download("wordnet")

--- a/datadreamer/prompt_generation/wordnet_synonym_generator.py
+++ b/datadreamer/prompt_generation/wordnet_synonym_generator.py
@@ -48,6 +48,10 @@ class WordNetSynonymGenerator(SynonymGenerator):
                     synonyms.add(lemma.name().replace("_", " "))
         return list(synonyms)[: self.synonyms_number]
 
+    def release(self, empty_cuda_cache: bool = False) -> None:
+        """Releases resources (no action is taken in this implementation)."""
+        pass
+
 
 if __name__ == "__main__":
     # Example usage

--- a/datadreamer/prompt_generation/wordnet_synonym_generator.py
+++ b/datadreamer/prompt_generation/wordnet_synonym_generator.py
@@ -1,0 +1,59 @@
+from typing import List, Optional
+
+import nltk
+from nltk.corpus import wordnet
+
+from .synonym_generator import SynonymGenerator
+
+# Ensure that WordNet data is downloaded
+nltk.download("wordnet")
+
+
+class WordNetSynonymGenerator(SynonymGenerator):
+    """Synonym generator that generates synonyms for a list of words using WordNet.
+
+    Args:
+        synonyms_number (int): Number of synonyms to generate for each word.
+        seed (Optional[float]): Seed for randomization.
+        device (str): Device to run the prompt generator on ('cuda' for GPU, 'cpu' for CPU).
+
+    Methods:
+        generate_synonyms(word): Generates synonyms for a single word and returns them in a list.
+    """
+
+    def __init__(
+        self,
+        synonyms_number: int = 5,
+        seed: Optional[float] = 42,
+        device: str = "cuda",
+    ) -> None:
+        """Initializes the SynonymGenerator with parameters."""
+        super().__init__(synonyms_number, seed, device)
+
+    def generate_synonyms(self, word: str) -> List[str]:
+        """Generates synonyms for a single word and returns them in a list.
+
+        Args:
+            word (str): The word for which synonyms are generated.
+
+        Returns:
+            List[str]: A list of generated synonyms for the word.
+        """
+        synonyms = set()
+        for syn in wordnet.synsets(word):
+            word_class = syn.pos()
+            for lemma in syn.lemmas():
+                # Check if the synonym has the same word class as the input word
+                if wordnet.synsets(lemma.name(), pos=word_class):
+                    synonyms.add(lemma.name().replace("_", " "))
+        return list(synonyms)[: self.synonyms_number]
+
+
+if __name__ == "__main__":
+    # Example usage
+    generator = WordNetSynonymGenerator(synonyms_number=3)
+    synonyms = generator.generate_synonyms_for_list(
+        ["astronaut", "cat", "dog", "person", "horse"]
+    )
+    print(synonyms)
+    generator.save_synonyms(synonyms, "synonyms.json")

--- a/examples/generate_dataset_and_train_yolo.ipynb
+++ b/examples/generate_dataset_and_train_yolo.ipynb
@@ -81,7 +81,7 @@
         "- `--image_annotator`: Specify the image annotator, like `owlv2`. Default is `owlv2`.\n",
         "- `--conf_threshold`: Confidence threshold for object detection. Default is 0.15.\n",
         "- `--use_tta`: Toggle test time augmentation for object detection. Default is True.\n",
-        "- `--enhance_class_names`: Enhance class names with synonyms. Default is False.\n",
+        "- `--synonym_generator`: Enhance class names with synonyms. Default is `none`. Other options are `llm`, `wordnet`.\n",
         "- `--use_image_tester`: Use image tester for image generation. Default is False. Image tester is a model that checks if the generated image contains the desired object.\n",
         "- `--image_tester_patience`: Patience level for image tester. Default is 1. Number of images to run through the image tester before giving up.\n",
         "- `--lm_quantization`: Quantization to use for Mistral language model. Choose between `none` and `4bit`. Default is `none`.\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ opencv-python>=4.7.0
 accelerate>=0.25.0
 scipy>=1.10.0
 bitsandbytes>=0.42.0
+nltk>=3.8.1

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -150,6 +150,12 @@ def test_invalid_seed():
     _check_wrong_value(cmd)
 
 
+def test_invalid_synonym_generator():
+    # Define the cmd
+    cmd = "datadreamer --device cpu --synonym_generator invalid"
+    _check_wrong_value(cmd)
+
+
 def test_invalid_lm_quantization():
     # Define the cmd
     cmd = "datadreamer --device cude --lm_quantization invalid"
@@ -255,9 +261,9 @@ def test_cuda_simple_sdxl_turbo_detection_pipeline():
     not torch.cuda.is_available() or total_memory < 16 or total_disk_space < 55,
     reason="Test requires GPU, at least 16GB of RAM and 55GB of HDD",
 )
-def test_cuda_simple_enhance_sdxl_turbo_detection_pipeline():
+def test_cuda_simple_llm_synonym_sdxl_turbo_detection_pipeline():
     # Define target folder
-    target_folder = "data/data-det-cuda-simple-enhance-sdxl-turbo/"
+    target_folder = "data/data-det-cuda-simple-llm-synonym-sdxl-turbo/"
     # Define the command to run the datadreamer
     cmd = (
         f"datadreamer --save_dir {target_folder} "
@@ -267,7 +273,30 @@ def test_cuda_simple_enhance_sdxl_turbo_detection_pipeline():
         f"--num_objects_range 1 2 "
         f"--image_generator sdxl-turbo "
         f"--use_image_tester "
-        f"--enhance_class_names "
+        f"--synonym_generator llm "
+        f"--device cuda"
+    )
+    # Check the run of the pipeline
+    _check_detection_pipeline(cmd, target_folder)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or total_memory < 16 or total_disk_space < 35,
+    reason="Test requires GPU, at least 16GB of RAM and 35GB of HDD",
+)
+def test_cuda_simple_wordnet_synonym_sdxl_turbo_detection_pipeline():
+    # Define target folder
+    target_folder = "data/data-det-cuda-simple-wordnet-synonym-sdxl-turbo/"
+    # Define the command to run the datadreamer
+    cmd = (
+        f"datadreamer --save_dir {target_folder} "
+        f"--class_names alien mars cat "
+        f"--prompts_number 1 "
+        f"--prompt_generator simple "
+        f"--num_objects_range 1 2 "
+        f"--image_generator sdxl-turbo "
+        f"--use_image_tester "
+        f"--synonym_generator wordnet "
         f"--device cuda"
     )
     # Check the run of the pipeline
@@ -643,9 +672,9 @@ def test_cuda_simple_sdxl_turbo_classification_pipeline():
     not torch.cuda.is_available() or total_memory < 16 or total_disk_space < 55,
     reason="Test requires GPU, at least 16GB of RAM and 55GB of HDD",
 )
-def test_cuda_simple_enhance_sdxl_turbo_classification_pipeline():
+def test_cuda_simple_llm_synonym_sdxl_turbo_classification_pipeline():
     # Define target folder
-    target_folder = "data/data-cls-cuda-simple-enhance-sdxl-turbo/"
+    target_folder = "data/data-cls-cuda-simple-llm-synonym-sdxl-turbo/"
     # Define the command to run the datadreamer
     cmd = (
         f"datadreamer --task classification "
@@ -656,7 +685,31 @@ def test_cuda_simple_enhance_sdxl_turbo_classification_pipeline():
         f"--num_objects_range 1 2 "
         f"--image_generator sdxl-turbo "
         f"--use_image_tester "
-        f"--enhance_class_names "
+        f"--synonym_generator llm "
+        f"--device cuda"
+    )
+    # Check the run of the pipeline
+    _check_detection_pipeline(cmd, target_folder)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or total_memory < 16 or total_disk_space < 35,
+    reason="Test requires GPU, at least 16GB of RAM and 35GB of HDD",
+)
+def test_cuda_simple_wordnet_synonym_sdxl_turbo_classification_pipeline():
+    # Define target folder
+    target_folder = "data/data-cls-cuda-simple-wordnet-synonym-sdxl-turbo/"
+    # Define the command to run the datadreamer
+    cmd = (
+        f"datadreamer --task classification "
+        f"--save_dir {target_folder} "
+        f"--class_names alien mars cat "
+        f"--prompts_number 1 "
+        f"--prompt_generator simple "
+        f"--num_objects_range 1 2 "
+        f"--image_generator sdxl-turbo "
+        f"--use_image_tester "
+        f"--synonym_generator wordnet "
         f"--device cuda"
     )
     # Check the run of the pipeline

--- a/tests/unittests/test_prompt_generation.py
+++ b/tests/unittests/test_prompt_generation.py
@@ -3,10 +3,13 @@ import pytest
 import torch
 
 from datadreamer.prompt_generation.lm_prompt_generator import LMPromptGenerator
+from datadreamer.prompt_generation.lm_synonym_generator import LMSynonymGenerator
 from datadreamer.prompt_generation.simple_prompt_generator import SimplePromptGenerator
-from datadreamer.prompt_generation.synonym_generator import SynonymGenerator
 from datadreamer.prompt_generation.tinyllama_lm_prompt_generator import (
     TinyLlamaLMPromptGenerator,
+)
+from datadreamer.prompt_generation.wordnet_synonym_generator import (
+    WordNetSynonymGenerator,
 )
 
 # Get the total memory in GB
@@ -103,9 +106,9 @@ def test_cpu_tinyllama_lm_prompt_generator():
     _check_lm_prompt_generator("cpu", TinyLlamaLMPromptGenerator)
 
 
-def _check_synonym_generator(device: str):
+def _check_synonym_generator(device: str, synonym_generator_class=LMSynonymGenerator):
     synonyms_num = 3
-    generator = SynonymGenerator(synonyms_number=synonyms_num, device=device)
+    generator = synonym_generator_class(synonyms_number=synonyms_num, device=device)
     synonyms = generator.generate_synonyms_for_list(["astronaut", "cat", "dog"])
     # Check that the some synonyms were generated
     assert len(synonyms) > 0
@@ -113,8 +116,8 @@ def _check_synonym_generator(device: str):
     for word, synonym_list in synonyms.items():
         # Check that the word is not empty
         assert len(word) > 0
-        # Check that the synonym list is not empty and has the correct number of synonyms
-        assert len(synonym_list) > 0 and len(synonym_list) == synonyms_num
+        # Check that the synonym list is not empty
+        assert len(synonym_list) > 0
         # Check that the synonyms are not empty
         for synonym in synonym_list:
             assert len(synonym) > 0
@@ -135,3 +138,15 @@ def test_cuda_synonym_generator():
 )
 def test_cpu_synonym_generator():
     _check_synonym_generator("cpu")
+
+
+def test_cpu_wordnet_synonym_generator():
+    _check_synonym_generator("cpu", WordNetSynonymGenerator)
+
+
+@pytest.mark.skipif(
+    torch.cuda.is_available(),
+    reason="Test requires CUDA support",
+)
+def test_cuda_wordnet_synonym_generator():
+    _check_synonym_generator("cuda", WordNetSynonymGenerator)


### PR DESCRIPTION
This PR includes:

- creating an abstract class for synonym generation
- adding WordNet synonym generator

Comparison of Mistral synonym generator vs WordNet:

| Object  | Mistral Generated Synonyms | WordNet Generated Synonyms |
| ------------- | ------------- | ------------- |
| astronaut  | ['astronaut', 'cosmonaut', 'spaceman'] | ['spaceman', 'astronaut', 'cosmonaut']  |
| cat  | ['feline', 'kitty', 'puss']  | ['throw up', 'bozo', 'kat']  |
| dog  | ['cat', 'pup', 'hound']  | ['chase', 'weenie', 'wienerwurst']  |
| person  | ['individual', 'human', 'being']  | ['mortal', 'individual', 'soul']  |
| horse  | ['horse', 'equine', 'nag']  | ['sawhorse', 'knight', 'gymnastic horse']  |
| car  | ['automobile', 'vehicle', 'transportation']  | ['cable car', 'automobile', 'elevator car']  |
| alien  | ['Extraterrestrial', 'extraneous', 'foreign']  | ['disaffect', 'extraterrestrial', 'foreigner'] |
| city  | ['town', 'urban area', 'metropolis']  | ['metropolis', 'urban center', 'city'] |
| plane  | ['level', 'flat', 'even']  | ['aeroplane', 'planer', 'shave']  |
| airport  | ['airport', 'terminal', 'aviation']  | ['aerodrome', 'airport', 'drome']  |
| robot  | ['machine', 'automaton', 'mechanism']  | ['golem', 'robot', 'automaton']  |
| tractor  | ['Tractor', 'Truck', 'Vehicle']  | ['tractor']  |
| bus  | ['1 vehicle', '2 coach', '3 publictransport']  | ['motorbus', 'passenger vehicle', 'autobus']  |
| bicycle  | ['bicycle', 'bike', 'bicycle']  | ['pedal', 'cycle', 'wheel']  |


Latency (measured on device with 30GB RAM, L4 24GB gpu) of generation 3 synonyms for 14 objects:

- Mistral: 8 seconds
- WordNet: 1 second