### PR TITLE
Fix: save images as PNG with full quality

### DIFF
--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -501,9 +501,9 @@ def main():
                 image = Image.fromarray(image)
                 unique_id = uuid.uuid4().hex
                 image_path = os.path.join(
-                    save_dir, f"image_{batch_num * batch_size + i}_{unique_id}.jpg"
+                    save_dir, f"image_{batch_num * batch_size + i}_{unique_id}.png"
                 )
-                image.save(image_path)
+                image.save(image_path, quality=100)
                 images.append(image)
                 batch_image_paths.append(image_path)
 


### PR DESCRIPTION
Small fix to ensure that images are saved in full quality and as PNG, such that the bytes will not change by any form of compression.