### PR TITLE
Fix: loader plugin arg to load image paths

### DIFF
--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -466,6 +466,7 @@ def main():
                 image_batches = LOADERS_REGISTRY.get(args.loader_plugin)(
                     view="all",
                     dataset_id=os.getenv("DATASET_ID"),
+                    sync_target_directory=save_dir,
                     load_image_paths=True,
                 )
             else:

--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -464,7 +464,9 @@ def main():
         if args.loader_plugin:
             if "DATASET_ID" in os.environ:
                 image_batches = LOADERS_REGISTRY.get(args.loader_plugin)(
-                    view="all", dataset_id=os.getenv("DATASET_ID"), load_image_paths=True
+                    view="all",
+                    dataset_id=os.getenv("DATASET_ID"),
+                    load_image_paths=True,
                 )
             else:
                 raise ValueError(

--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -464,7 +464,7 @@ def main():
         if args.loader_plugin:
             if "DATASET_ID" in os.environ:
                 image_batches = LOADERS_REGISTRY.get(args.loader_plugin)(
-                    view="all", dataset_id=os.getenv("DATASET_ID")
+                    view="all", dataset_id=os.getenv("DATASET_ID"), load_image_paths=True
                 )
             else:
                 raise ValueError(
@@ -501,9 +501,9 @@ def main():
                 image = Image.fromarray(image)
                 unique_id = uuid.uuid4().hex
                 image_path = os.path.join(
-                    save_dir, f"image_{batch_num * batch_size + i}_{unique_id}.png"
+                    save_dir, f"image_{batch_num * batch_size + i}_{unique_id}.jpg"
                 )
-                image.save(image_path, quality=100)
+                image.save(image_path)
                 images.append(image)
                 batch_image_paths.append(image_path)
 


### PR DESCRIPTION
I discovered we cannot actually get an exact byte match from saving images from `np.ndarray` unless we know the details of the underlying compression algorithm of the image we read from.

Instead, I've introduced an argument for loader plugins `load_image_paths` which, if implemented, would return `images_batch` as a `List[str]` of filepaths. This allows for an exact byte match if needed, since we just take the underlying image.

I've reverted the changes in #60 because I think we're better off without them. In most use cases, there is no need to have 100% quality if we're saving from numpy.