### PR TITLE
Rework GHCR publish actions

### DIFF
--- a/.github/workflows/gar-publish.yaml
+++ b/.github/workflows/gar-publish.yaml
@@ -4,8 +4,6 @@ name: Deploy single image to GAR (Google Artifact Registry)
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
 env:
   PROJECT_ID: easyml-394818
   GAR_LOCATION: us-central1

--- a/.github/workflows/ghcr-publish-manual.yaml
+++ b/.github/workflows/ghcr-publish-manual.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: 'Extract short commit hash'
         id: commit_hash
-        run: echo "::set-output name=short_hash::$(git rev-parse --short HEAD)"
+        run: echo "short_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Docker login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/ghcr-publish-manual.yaml
+++ b/.github/workflows/ghcr-publish-manual.yaml
@@ -1,0 +1,41 @@
+name: Manually deploy image to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'dev'
+
+env:
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_NAME: datadreamer
+
+jobs:
+  push-store:
+    name: Push the image to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}  # Checkout the selected branch
+
+      - name: 'Extract short commit hash'
+        id: commit_hash
+        run: echo "::set-output name=short_hash::$(git rev-parse --short HEAD)"
+
+      - name: Docker login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: luxonis-ml
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: 'Build and Push Image to GHCR'
+        run: |
+          docker build --build-arg GITHUB_TOKEN=${{secrets.GHCR_PAT}} --build-arg BRANCH=${{ inputs.branch }} . \
+            --tag ghcr.io/luxonis/datadreamer:${{ steps.commit_hash.outputs.short_hash }}
+          docker push ghcr.io/luxonis/datadreamer --all-tags

--- a/.github/workflows/ghcr-publish.yaml
+++ b/.github/workflows/ghcr-publish.yaml
@@ -1,4 +1,4 @@
-name: Docker Build and Publish
+name: Deploy latest image to GHCR on release
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to improve deployment processes for images to GitHub Container Registry (GHCR).

Changes to deployment workflows:

* [`.github/workflows/gar-publish.yaml`](diffhunk://#diff-e346be641815d502f436a67ba39cbd7e9726f58c345f7862abbcbbfe09d4781eL7-L8): Removed the release trigger from the GAR deployment workflow to streamline the deployment process.

* [`.github/workflows/ghcr-publish-manual.yaml`](diffhunk://#diff-9f7f4605b5097403ef86fa8d3ff2ca801e2f8f8358dc7786c7b64bed99445f58R1-R41): Added a new workflow to manually deploy images to GHCR, including steps for checking out the branch, extracting the commit hash, logging into GHCR, and building and pushing the image.

* [`.github/workflows/ghcr-publish.yaml`](diffhunk://#diff-da6c2304063c8c0219c1debef3460a812947e5224ca62c9ceb3995eeb1c19044L1-R1): Renamed the existing GHCR deployment workflow to clarify that it deploys the latest image on release.