### PR TITLE
Fix: convert images to RGB

### DIFF
--- a/datadreamer/pipelines/generate_dataset_from_scratch.py
+++ b/datadreamer/pipelines/generate_dataset_from_scratch.py
@@ -552,7 +552,9 @@ def main():
                 batch_image_paths.append(image_path)
 
         else:
-            images = [Image.open(image_path) for image_path in image_batch]
+            images = [
+                Image.open(image_path).convert("RGB") for image_path in image_batch
+            ]
             batch_image_paths = image_batch
         return images, batch_image_paths
 

--- a/examples/generate_instance_segmentation_dataset_and_train_yolo.ipynb
+++ b/examples/generate_instance_segmentation_dataset_and_train_yolo.ipynb
@@ -25,7 +25,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q datadreamer@git+https://github.com/luxonis/datadreamer@dev"
+        "!pip install -q datadreamer"
       ]
     },
     {

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">75%</text>
-        <text x="80" y="14">75%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">63%</text>
+        <text x="80" y="14">63%</text>
     </g>
 </svg>


### PR DESCRIPTION
This PR:

- fixes issues with annotating images which aren't in RGB format and so their annotation fails.
- updates the installation command in an instance segmentation example.