### PR TITLE
Fix: LuxonisDataset Converter - bbox computation

### DIFF
--- a/datadreamer/utils/luxonis_dataset_converter.py
+++ b/datadreamer/utils/luxonis_dataset_converter.py
@@ -109,18 +109,18 @@ class LuxonisDatasetConverter(BaseConverter):
                 if "boxes" in data[image_path]:
                     boxes = data[image_path]["boxes"]
                     for box, label in zip(boxes, labels):
-                        x, y, w, h = box[0], box[1], box[2] - box[0], box[3] - box[1]
-                        x = max(0, x)
-                        y = max(0, y)
+                        x, y = max(0, box[0] / width), max(0, box[1] / height)
+                        w = min(box[2] / width - x, 1 - x)
+                        h = min(box[3] / height - y, 1 - y)
                         yield {
                             "file": image_full_path,
                             "annotation": {
                                 "class": class_names[label],
                                 "type": "boundingbox",
-                                "x": x / width,
-                                "y": y / height,
-                                "w": w / width,
-                                "h": h / height,
+                                "x": x,
+                                "y": y,
+                                "w": w,
+                                "h": h,
                             },
                         }
 

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">75%</text>
-        <text x="80" y="14">75%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">63%</text>
+        <text x="80" y="14">63%</text>
     </g>
 </svg>


### PR DESCRIPTION
The PR solves the issue with having `x_max` or `y_max` when re-computed from `x`, `y`, `w`, and `h` to be <= 1.0.