### PR TITLE
Add instance segmentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ datadreamer --class_names person moon robot
 
 ### ✨ New: Pre-annotate Real Data with DataDreamer
 
-DataDreamer helps you accelerate your annotation process by pre-annotating real data with minimal effort. Simply provide your dataset, and DataDreamer generates high-quality initial annotations for further refinement.
+`DataDreamer` helps you accelerate your annotation process by pre-annotating real data with minimal effort. Simply provide your dataset, and `DataDreamer` generates high-quality initial annotations for further refinement.
 
-Available tasks are: classification, object detection, and instance segmentation.
+Available tasks: classification, object detection, and instance segmentation.
 
 <img src='images/dumplings_seg_preannotation.gif' align="center">
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ datadreamer --class_names person moon robot
 
 - **Efficient and Potent Models**: The primary objective of `DataDreamer` is to enable the creation of compact models that are both size-efficient for integration into any device and robust in performance for specialized tasks.
 
+### ✨ New: Pre-annotate Real Data with DataDreamer
+
+DataDreamer helps you accelerate your annotation process by pre-annotating real data with minimal effort. Simply provide your dataset, and DataDreamer generates high-quality initial annotations for further refinement.
+
+Available tasks are: classification, object detection, and instance segmentation.
+
+<img src='images/dumplings_seg_preannotation.gif' align="center">
+
+#### Example
+
+Run the following to pre-annotate images in your dataset:
+
+```bash
+datadreamer --save_dir dataset_path --class_names dumpling --annotate_only
+```
+
+📚 **Tutorial**: [Training a Semantic Segmentation Model using luxonis-train and DataDreamer](https://github.com/luxonis/depthai-ml-training/blob/main/training/luxonis-train/train_semantic_segmentation_model_datadreamer.ipynb)
+
 ## 📜 Table of contents
 
 - [🚀 Quickstart](#quickstart)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Available tasks: classification, object detection, and instance segmentation.
 Run the following to pre-annotate images in your dataset:
 
 ```bash
-datadreamer --save_dir dataset_path --class_names dumpling --annotate_only
+datadreamer --task instance-segmentation --image_annotator owlv2-slimsam --save_dir dataset_path --class_names dumpling --annotate_only
 ```
 
 📚 **Tutorial**: [Training a Semantic Segmentation Model using luxonis-train and DataDreamer](https://github.com/luxonis/depthai-ml-training/blob/main/training/luxonis-train/train_semantic_segmentation_model_datadreamer.ipynb)
@@ -175,7 +175,7 @@ datadreamer --config <path-to-config>
 
 ### 🔧 Additional Parameters
 
-- `--task`: Choose between detection, classification and instance segmentation. Default is `detection`.
+- `--task`: Choose between `detection`, `classification` and `instance-segmentation`. Default is `detection`.
 - `--dataset_format`: Format of the dataset. Defaults to `raw`. Supported values: `raw`, `yolo`, `coco`, `luxonis-dataset`, `cls-single`.
 - `--split_ratios`: Split ratios for train, validation, and test sets. Defaults to `[0.8, 0.1, 0.1]`.
 - `--num_objects_range`: Range of objects in a prompt. Default is 1 to 3.


### PR DESCRIPTION
This pull request includes an update to the `README.md` to highlight a feature in `DataDreamer` for pre-annotating real data. The most important changes are as follows:

Example and tutorial:

* Added a visualization of pre-annotation results
* Provided an example command to demonstrate how to use the new pre-annotation feature with `DataDreamer`.
* Included a link to a tutorial on training a semantic segmentation model using `luxonis-train` and `DataDreamer`.