### PR TITLE
Add disabling LM filter

### DIFF
--- a/examples/generate_dataset_and_train_yolo.ipynb
+++ b/examples/generate_dataset_and_train_yolo.ipynb
@@ -59,6 +59,7 @@
     "!datadreamer --save_dir generated_dataset \\\n",
     "             --class_names robot tractor horse car person bear \\\n",
     "             --prompts_number 100 \\\n",
+    "             --disable_lm_filter \\\n",
     "             --prompt_generator simple \\\n",
     "             --num_objects_range 2 3 \\\n",
     "             --image_generator sdxl-turbo \\\n",

--- a/examples/helmet_detection.ipynb
+++ b/examples/helmet_detection.ipynb
@@ -55,6 +55,7 @@
     "!datadreamer --save_dir gen_dataset_helmet_10000_turbo_tiny \\\n",
     "             --class_names helmet \\\n",
     "             --prompts_number 10000 \\\n",
+    "             --disable_lm_filter \\\n",
     "             --prompt_generator tiny \\\n",
     "             --num_objects_range 1 1 \\\n",
     "             --image_generator sdxl-turbo \\\n",


### PR DESCRIPTION
This PR adds the `--disable_lm_filter` argument to the Jupyter Notebooks to take less memory (in case of `generate_dataset_and_train_yolo.ipynb` to fit on GPU on Google Colab.