### PR TITLE
Add `workflow_call` support in unittests workflow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -71,6 +71,19 @@ jobs:
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
+
+    - name: Install specified luxonis-ml
+      shell: bash
+      if: inputs.ml_ref != ''
+      working-directory: tools
+      env:
+        ML_REF: ${{ inputs.ml_ref }}
+      run: |
+        pip uninstall luxonis-ml -y
+        pip install \
+          "luxonis-ml[all] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \
+          --upgrade --force-reinstall
+
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
       working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,7 +7,16 @@ on:
       - 'datadreamer/**/**.py'
       - 'tests/core_tests/unittests/**.py'
       - .github/workflows/unit-tests.yaml
-    workflow_dispatch:
+    workflow_call:
+      inputs:
+        ml_ref:
+          description: 'luxonis-ml version (branch/tag/SHA)'
+          required: true
+          type: string
+        datadreamer_ref:
+          description: 'datadreamer version (branch/tag/SHA)'
+          required: true
+          type: string
 
 jobs:
   run_tests:
@@ -24,8 +33,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         ref: ${{ github.head_ref }}
+
+    - name: Checkout at datadreamer_ref
+      if: ${{ inputs.datadreamer_ref != ''}}
+      uses: actions/checkout@v4
+      with:
+        repository: Luxonis/datadreamer
+        ref:        ${{ inputs.datadreamer_ref }}
+        path:       datadreamer
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -35,6 +53,7 @@ jobs:
 
     - name: Install dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'
+      working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}
       run: |
         sudo apt update
         sudo apt install -y pandoc
@@ -42,35 +61,39 @@ jobs:
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
     - name: Install dependencies [Windows]
       if: matrix.os == 'windows-latest'
+      working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
     - name: Install dependencies [macOS]
       if: matrix.os == 'macOS-latest'
+      working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}
       run: pytest tests/core_tests/unittests --cov=datadreamer --cov-report xml --junit-xml pytest.xml
 
     - name: Run tests [Windows, macOS]
       if: matrix.os != 'ubuntu-latest' || matrix.version != '3.10'
+      working-directory: ${{ inputs.datadreamer_ref != '' && 'datadreamer' || '' }}
       run: pytest tests/core_tests/unittests --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       run: coverage-badge -o media/coverage_badge.svg -f
 
     - name: Generate coverage report [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       uses: orgoro/coverage@v3.1
       with:
         coverageFile: coverage.xml
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit coverage badge [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       run: |
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
@@ -79,13 +102,13 @@ jobs:
           git commit -m "[Automated] Updated coverage badge"
         }
     - name: Push changes [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.head_ref }}
 
     - name: Upload Test Results
-      if: always()
+      if: always() && github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: Test Results [${{ matrix.os }}] (Python ${{ matrix.version }})
@@ -100,7 +123,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-    if: always()
+    if: always() && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**PR Description:**  
- Introduce `workflow_call` with `ml_ref` and `datadreamer_ref` inputs  
- Checkout `datadreamer` at specified ref when invoked externally  
- Install the target `luxonis-ml` version via `ml_ref`  
- Preserve existing behavior for PR-triggered runs  
- Enables BOM tests on external repos to validate integration in `datadreamer`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable